### PR TITLE
layout() shortcut missing from Breeze.php

### DIFF
--- a/lib/Breeze.php
+++ b/lib/Breeze.php
@@ -540,6 +540,25 @@ function template()
     );
 }
 
+/**
+ * Sets the layout to use.
+ *
+ * @code
+ *     // Path resolves to views/path/to/layout.php
+ *     layout('path/to/layout');
+ * @endcode
+ *
+ * @param string $path The path to the layout file
+ *
+ * @return void
+ */
+function layout()
+{
+    return call_user_func_array(
+        array(Application::getInstance('breeze'), 'layout'), func_get_args()
+    );
+}
+
 // Moves all user-defined helpers to the global scope
 foreach (Application::getInstance('breeze')->getUserHelpers() as $helper) {
     eval(


### PR DESCRIPTION
When I attempted to use the `layout()` shortcut in a controller, I received the following error:

```
Fatal error:  Call to undefined function layout() in /home/matt/Documents/projects/rcp/website/controllers/Index.php on line 4
Stack trace:
  1. {main}() /home/matt/Documents/projects/rcp/website/public/index.php:0
  2. require_once() /home/matt/Documents/projects/rcp/website/public/index.php:3
  3. run() /home/matt/Documents/projects/rcp/website/bootstrap.php:12
  4. call_user_func_array(array (0 => class Breeze\\Application { protected $_configurations = class Breeze\\Configurations { ... }; protected $_view = class Breeze\\View\\View { ... }; protected $_dispatcher = class Breeze\\Dispatcher\\Dispatcher { ... }; protected $_conditions = class Breeze\\Dispatcher\\Conditions { ... }; protected $_errorHandler = class Breeze\\Errors\\Errors { ... }; protected $_status = class Breeze\\Dispatcher\\Status { ... }; protected $_userHelpers = class Breeze\\ClosuresCollection { ... }; protected $_filters = array (...) }, 1 => 'run'), array ()) /home/matt/Documents/projects/rcp/website/lib/breeze/lib/Breeze.php:491
  5. Breeze\\Application->run($requestMethod = *uninitialized*, $requestUri = *uninitialized*) /home/matt/Documents/projects/rcp/website/lib/breeze/lib/Breeze.php:0
  6. Breeze\\Application->filter($type = 'before') /home/matt/Documents/projects/rcp/website/lib/breeze/lib/Breeze/Application.php:2565
  7. {closure}(class Breeze\\Application { protected $_configurations = class Breeze\\Configurations { protected $_configurations = array (...) }; protected $_view = class Breeze\\View\\View { protected $_application = ...; protected $_templateVariables = array (...); protected $_engine = NULL }; protected $_dispatcher = class Breeze\\Dispatcher\\Dispatcher { protected $_application = ...; protected $_requestUri = NULL; protected $_requestMethod = 'GET'; protected $_routes = array (...) }; protected $_conditions = class Breeze\\Dispatcher\\Conditions { protected $_namedClosures = array (...); protected $_closures = array (...) }; protected $_errorHandler = class Breeze\\Errors\\Errors { protected $_defaultError = class Closure { ... }; protected $_application = ...; protected $_namedClosures = array (...); protected $_closures = array (...) }; protected $_status = class Breeze\\Dispatcher\\Status { protected $_statusCode = 200; protected $_statusMessage = 'OK'; protected $_httpVersion = '1.1' }; protected $_userHelpers = class Breeze\\ClosuresCollection { protected $_namedClosures = array (...); protected $_closures = array (...) }; protected $_filters = array ('before' => class Breeze\\ClosuresCollection { ... }, 'after' => class Breeze\\ClosuresCollection { ... }) }) /home/matt/Documents/projects/rcp/website/lib/breeze/lib/Breeze/Application.php:2548
```

Upon inspection, `Breeze.php` contains no declaration for it. This patch adds one. Upon its addition, the error cited above no longer occurs and I receive the expected response from the application.
