### PR TITLE
Small typo correction in the name of a dispatcher test case method

### DIFF
--- a/test/Breeze/Dispatcher/DispatcherTest.php
+++ b/test/Breeze/Dispatcher/DispatcherTest.php
@@ -207,7 +207,7 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
      * Tests {@link Breeze\Dispatcher\Dispatcher::dispatch()} to
      * set the request method.
      */
-    public function testSetRequesMethodFromDispatch()
+    public function testSetRequestMethodFromDispatch()
     {
         foreach (self::$_supportedMethods as $method) {
             try {


### PR DESCRIPTION
"testSetRequesMethodFromDispatch" is missing the "t" before the "M"
