### PR TITLE
Breeze/Application::getInstance() should be static

### DIFF
--- a/lib/Breeze/Application.php
+++ b/lib/Breeze/Application.php
@@ -2053,7 +2053,7 @@ class Application
      *
      * @return Breeze\Application
      */
-    public function getInstance($name, Configurations $configurations = null)
+    public static function getInstance($name, Configurations $configurations = null)
     {
         if (!isset(self::$_instances[$name])) {
             self::$_instances[$name] = new self($configurations);


### PR DESCRIPTION
Fixed Breeze/Application not being declared as a static function despite being called as one in numerous areas of the codebase
